### PR TITLE
Feature proposal: squashing categories

### DIFF
--- a/packages/docusaurus-plugin-openapi/src/sidebars/index.ts
+++ b/packages/docusaurus-plugin-openapi/src/sidebars/index.ts
@@ -116,9 +116,12 @@ export async function generateSidebar(
       // Otherwise, create a new one.
       const newCategory = {
         type: "category" as const,
+        className: meta?.className,
+        customProps: meta?.customProps,
+        position: meta?.position,
         label,
-        collapsible: options.sidebarCollapsible,
-        collapsed: options.sidebarCollapsed,
+        collapsible: meta?.collapsible ?? options.sidebarCollapsible,
+        collapsed: meta?.collapsed ?? options.sidebarCollapsed,
         items: [],
       };
       visiting.push(newCategory);
@@ -129,6 +132,19 @@ export async function generateSidebar(
   // The first group should always be a category, but check for type narrowing
   if (sidebar.length === 1 && sidebar[0].type === "category") {
     return sidebar[0].items;
+  }
+
+  // Squash categories that only contain a single API spec
+  if (sidebar.length > 0) {
+    for (const item of sidebar) {
+      if (
+        item.type === "category" &&
+        item.items.length === 1 &&
+        item.items[0].type === "category"
+      ) {
+        item.items = item.items[0].items;
+      }
+    }
   }
 
   return sidebar;

--- a/packages/docusaurus-plugin-openapi/src/sidebars/index.ts
+++ b/packages/docusaurus-plugin-openapi/src/sidebars/index.ts
@@ -201,7 +201,7 @@ function groupByTags(items: Item[], options: Options): PropSidebar {
     })
     .filter((item) => item.items.length > 0); // Filter out any categories with no items.
 
-  const untagged = [
+  let untagged = [
     {
       type: "category" as const,
       label: "API",
@@ -212,6 +212,10 @@ function groupByTags(items: Item[], options: Options): PropSidebar {
         .map(createLink),
     },
   ];
+
+  if (untagged[0].items.length === 0) {
+    untagged = [];
+  }
 
   return [...intros, ...tagged, ...untagged];
 }

--- a/packages/docusaurus-plugin-openapi/src/sidebars/sidebars.test.ts
+++ b/packages/docusaurus-plugin-openapi/src/sidebars/sidebars.test.ts
@@ -167,9 +167,8 @@ describe("sidebars", () => {
       expect(cats.type).toBe("category");
       expect(cats.items).toHaveLength(1);
 
-      const [catApi] = (cats.items ?? []).filter(isCategory);
-      expect(catApi.type).toBe("category");
-      const [catLink] = catApi?.items;
+      // Check that the category has been squashed
+      const [catLink] = cats.items;
       expect(catLink.type).toBe("link");
       expect(dogs.type).toBe("category");
       expect(dogs.items).toHaveLength(1);
@@ -225,10 +224,9 @@ describe("sidebars", () => {
       const [cats, dogsSpec] = output;
       expect(cats.items).toHaveLength(1);
       expect(dogsSpec.type).toBe("category");
-      const [dogApi] = dogsSpec.items.filter(isCategory);
-      expect(dogApi?.items).toHaveLength(2);
-      expect(dogApi.label).toBe("API");
-      const [dogsItem] = dogApi.items;
+      expect(dogsSpec.items).toHaveLength(2);
+      expect(dogsSpec.label).toBe("dogs");
+      const [dogsItem] = dogsSpec.items;
       expect(dogsItem.label).toBe("List Dogs");
     });
 
@@ -316,7 +314,7 @@ describe("sidebars", () => {
       // console.log(JSON.stringify(output, null, 2));
       const [cats, dogs] = output;
       expect(cats.type).toBe("category");
-      expect(cats.items).toHaveLength(3); // extra api item category is included but gets filtered out later
+      expect(cats.items).toHaveLength(2);
       const [tails, whiskers] = (cats.items || []).filter(isCategory);
       expect(tails.type).toBe("category");
       expect(whiskers.type).toBe("category");
@@ -328,7 +326,7 @@ describe("sidebars", () => {
       expect(whiskers.items?.[0].label).toBe("List whiskers");
 
       expect(dogs.type).toBe("category");
-      expect(dogs.items).toHaveLength(3); // extra api item category is included but gets filtered out later
+      expect(dogs.items).toHaveLength(2);
       expect(dogs.label).toBe("Dogs");
       const [doggos, toys] = (dogs.items || []) as PropSidebarItemCategory[];
       expect(doggos.type).toBe("category");
@@ -375,12 +373,12 @@ describe("sidebars", () => {
 
       /*
         animals
-          pets
+          pets <-- should not exist
             Cat Store
               cats
         Foods
-          Buger Store
-            Burger Example
+          Buger Store <-- should not exist
+            Burger Example  <-- should be called "Burger Store"
               burgers
       */
       output.filter(isCategory).forEach((category) => {
@@ -389,10 +387,7 @@ describe("sidebars", () => {
         category.items.filter(isCategory).forEach((subCategory) => {
           expect(subCategory.items[0].type).toBe("category");
           subCategory.items.filter(isCategory).forEach((groupCategory) => {
-            expect(groupCategory.items[0].type).toBe("category");
-            groupCategory.items.forEach((linkItem) => {
-              expect(linkItem.type).toBe("category");
-            });
+            expect(groupCategory.items[0].type).toBe("link");
           });
         });
       });


### PR DESCRIPTION
This allows docusaurus-api to behave a bit more like docusaurus. When you have a folder with only a single file inside, docusaurus applies the `_category_` metadata to the item itself instead of creating an additional category.

This PR adds the same behavior for multi-spec pages.

Example: say you have this folder structure:

<img width="270" alt="Screenshot 2022-06-24 at 18 04 29" src="https://user-images.githubusercontent.com/402652/175574583-962af230-eaf1-4c34-9b13-f938dda5aaee.png">

Right now, rendering this in a single page yields this:

<img width="719" alt="Screenshot 2022-06-24 at 18 04 14" src="https://user-images.githubusercontent.com/402652/175574645-693ddb6c-6ee4-409a-b14a-760c77c76b0f.png">

With the proposed changes, you can use the `_category_` file to apply metadata to the inner category (let's say you want a custom title, or you want to set `collapsible=false`). It also removes the duplicated category, if the outer category only contains a single item. Result:

<img width="552" alt="Screenshot 2022-06-24 at 18 02 56" src="https://user-images.githubusercontent.com/402652/175574888-a4697fcf-b2d8-4c12-8c8c-80885e106ba8.png">

