### PR TITLE
Fix: escape html in param names

### DIFF
--- a/demo/examples/food/burgers/openapi.yaml
+++ b/demo/examples/food/burgers/openapi.yaml
@@ -8,6 +8,12 @@ paths:
     get:
       summary: List All Burgers
       description: Burgers
+      parameters:
+        - in: query
+          name: Calories<
+          schema:
+            type: string
+            description: Calories less than the given amount.
       responses:
         200:
           description: OK

--- a/packages/docusaurus-plugin-openapi/src/markdown/createParamsTable.ts
+++ b/packages/docusaurus-plugin-openapi/src/markdown/createParamsTable.ts
@@ -11,7 +11,7 @@ import { ApiItem } from "../types";
 import { createDescription } from "./createDescription";
 import { createFullWidthTable } from "./createFullWidthTable";
 import { getQualifierMessage, getSchemaName } from "./schema";
-import { create, escapeHtml, guard } from "./utils";
+import { create, guard } from "./utils";
 
 interface Props {
   parameters: ApiItem["parameters"];
@@ -44,7 +44,7 @@ export function createParamsTable({ parameters, type }: Props) {
           create("tr", {
             children: create("td", {
               children: [
-                create("code", { children: escapeHtml(param.name) }),
+                create("code", { children: escape(param.name) }),
                 guard(param.schema, (schema) =>
                   create("span", {
                     style: { opacity: "0.6" },

--- a/packages/docusaurus-plugin-openapi/src/markdown/createParamsTable.ts
+++ b/packages/docusaurus-plugin-openapi/src/markdown/createParamsTable.ts
@@ -11,7 +11,7 @@ import { ApiItem } from "../types";
 import { createDescription } from "./createDescription";
 import { createFullWidthTable } from "./createFullWidthTable";
 import { getQualifierMessage, getSchemaName } from "./schema";
-import { create, guard } from "./utils";
+import { create, escapeHtml, guard } from "./utils";
 
 interface Props {
   parameters: ApiItem["parameters"];
@@ -44,7 +44,7 @@ export function createParamsTable({ parameters, type }: Props) {
           create("tr", {
             children: create("td", {
               children: [
-                create("code", { children: param.name }),
+                create("code", { children: escapeHtml(param.name) }),
                 guard(param.schema, (schema) =>
                   create("span", {
                     style: { opacity: "0.6" },

--- a/packages/docusaurus-plugin-openapi/src/markdown/createSchemaTable.ts
+++ b/packages/docusaurus-plugin-openapi/src/markdown/createSchemaTable.ts
@@ -5,11 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  * ========================================================================== */
 
+import { escape } from "lodash";
+
 import { MediaTypeObject, SchemaObject } from "../openapi/types";
 import { createDescription } from "./createDescription";
 import { createFullWidthTable } from "./createFullWidthTable";
 import { getQualifierMessage, getSchemaName } from "./schema";
-import { create, escapeHtml, guard } from "./utils";
+import { create, guard } from "./utils";
 
 function resolveAllOf(allOf: SchemaObject[]) {
   // TODO: naive implementation (only supports objects, no directly nested allOf)
@@ -42,7 +44,7 @@ function createRow({ name, schema, required }: RowProps) {
   return create("tr", {
     children: create("td", {
       children: [
-        create("code", { children: escapeHtml(name) }),
+        create("code", { children: escape(name) }),
         create("span", {
           style: { opacity: "0.6" },
           children: ` ${getSchemaName(schema, true)}`,

--- a/packages/docusaurus-plugin-openapi/src/markdown/createSchemaTable.ts
+++ b/packages/docusaurus-plugin-openapi/src/markdown/createSchemaTable.ts
@@ -9,7 +9,7 @@ import { MediaTypeObject, SchemaObject } from "../openapi/types";
 import { createDescription } from "./createDescription";
 import { createFullWidthTable } from "./createFullWidthTable";
 import { getQualifierMessage, getSchemaName } from "./schema";
-import { create, guard } from "./utils";
+import { create, escapeHtml, guard } from "./utils";
 
 function resolveAllOf(allOf: SchemaObject[]) {
   // TODO: naive implementation (only supports objects, no directly nested allOf)
@@ -42,7 +42,7 @@ function createRow({ name, schema, required }: RowProps) {
   return create("tr", {
     children: create("td", {
       children: [
-        create("code", { children: name }),
+        create("code", { children: escapeHtml(name) }),
         create("span", {
           style: { opacity: "0.6" },
           children: ` ${getSchemaName(schema, true)}`,

--- a/packages/docusaurus-plugin-openapi/src/markdown/utils.ts
+++ b/packages/docusaurus-plugin-openapi/src/markdown/utils.ts
@@ -37,12 +37,3 @@ export function render(children: Children): string {
   }
   return children ?? "";
 }
-
-export function escapeHtml(unsafe: string) {
-  return unsafe
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#039;");
-}

--- a/packages/docusaurus-plugin-openapi/src/markdown/utils.ts
+++ b/packages/docusaurus-plugin-openapi/src/markdown/utils.ts
@@ -37,3 +37,12 @@ export function render(children: Children): string {
   }
   return children ?? "";
 }
+
+export function escapeHtml(unsafe: string) {
+  return unsafe
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#039;");
+}


### PR DESCRIPTION
This PR fixes a build failure when one of the openapi specs includes a parameter with html special characters.