### PR TITLE
ensure description from schema is not ignored

### DIFF
--- a/packages/docusaurus-plugin-openapi/src/markdown/createParamsTable.ts
+++ b/packages/docusaurus-plugin-openapi/src/markdown/createParamsTable.ts
@@ -70,6 +70,12 @@ export function createParamsTable({ parameters, type }: Props) {
                     children: createDescription(message),
                   })
                 ),
+                guard(param.schema?.description, (description) =>
+                  create("div", {
+                    style: { marginTop: "var(--ifm-table-cell-padding)" },
+                    children: createDescription(description),
+                  })
+                ),
                 guard(param.description, (description) =>
                   create("div", {
                     style: { marginTop: "var(--ifm-table-cell-padding)" },


### PR DESCRIPTION
Sometimes, a description is specified not as the attribute of a parameter but as the attribute of the parameter's schema. This PR ensures that the description is picked up correctly in both cases.

@bourdakos1 