### PR TITLE
chore: update template version

### DIFF
--- a/packages/docusaurus-template-openapi/template.json
+++ b/packages/docusaurus-template-openapi/template.json
@@ -1,7 +1,7 @@
 {
   "package": {
     "name": "demo",
-    "version": "0.4.0",
+    "version": "0.6.0",
     "private": true,
     "scripts": {
       "docusaurus": "docusaurus",
@@ -16,7 +16,7 @@
     },
     "dependencies": {
       "@docusaurus/core": "2.0.0-beta.21",
-      "docusaurus-preset-openapi": "0.4.0",
+      "docusaurus-preset-openapi": "0.6.0",
       "@mdx-js/react": "^1.6.21",
       "clsx": "^1.1.1",
       "prism-react-renderer": "^1.2.1",


### PR DESCRIPTION
Docusaurus OpenAPI supports creating template projects using npm commands, such as `yarn create docusaurus-openapi my-website`.

Currently, the version of the template project is still `0.4.0`
https://github.com/cloud-annotations/docusaurus-openapi/blob/255c6df6ce7061683b8365af10bb1135d7e146aa/packages/docusaurus-template-openapi/template.json#L19

Try updating the version to the latest `0.6.0`.

Feel free to let me know if I'm missing something 💖 
@bourdakos1 @danieleds 

