### PR TITLE
Fix: loading failed for local openapi json file on Windows

### DIFF
--- a/packages/docusaurus-plugin-openapi/src/util.test.ts
+++ b/packages/docusaurus-plugin-openapi/src/util.test.ts
@@ -4,6 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  * ========================================================================== */
+
 import { isURL } from "./util";
 
 describe("util", () => {

--- a/packages/docusaurus-plugin-openapi/src/util.test.ts
+++ b/packages/docusaurus-plugin-openapi/src/util.test.ts
@@ -1,8 +1,14 @@
+/* ============================================================================
+ * Copyright (c) Cloud Annotations
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ * ========================================================================== */
 import { isURL } from "./util";
 
 describe("util", () => {
   describe("isURL", () => {
-    it("full external link", async () => {
+    it("full external link", () => {
       const url = "http://www.google.com";
       expect(isURL(url)).toBe(true);
     });

--- a/packages/docusaurus-plugin-openapi/src/util.test.ts
+++ b/packages/docusaurus-plugin-openapi/src/util.test.ts
@@ -1,0 +1,23 @@
+import { isURL } from "./util";
+
+describe("util", () => {
+  describe("isURL", () => {
+    it("full external link", async () => {
+      const url = "http://www.google.com";
+      expect(isURL(url)).toBe(true);
+    });
+
+    it("Windows path", () => {
+      // this is a windows path checking
+      // related to issue #190
+      // https://github.com/cloud-annotations/docusaurus-openapi/issues/190
+      const url = "C:\\docusaurus-openapi\\openapi.json";
+      expect(isURL(url)).toBe(false);
+    });
+
+    it("Linux/Unix path", () => {
+      const url = "/mnt/c/Users/docusaurus-openapi/openapi.json";
+      expect(isURL(url)).toBe(false);
+    });
+  });
+});

--- a/packages/docusaurus-plugin-openapi/src/util.ts
+++ b/packages/docusaurus-plugin-openapi/src/util.ts
@@ -6,10 +6,5 @@
  * ========================================================================== */
 
 export const isURL = (url: string) => {
-  try {
-    new URL(url);
-    return true;
-  } catch (e) {
-    return false;
-  }
+  return /^(?:[a-z]+:)?\/\//i.test(url);
 };


### PR DESCRIPTION
**Close #190** 

Use regex to check if it's an external link instead of using the URL and try/catch.
It can support **Windows** platforms..

