### PR TITLE
fix(theme): new location for theme icons

### DIFF
--- a/packages/docusaurus-theme-openapi/src/theme/ApiPage/index.tsx
+++ b/packages/docusaurus-theme-openapi/src/theme/ApiPage/index.tsx
@@ -16,7 +16,7 @@ import type { ApiRoute } from "@theme/ApiItem";
 import type { Props } from "@theme/ApiPage";
 import BackToTopButton from "@theme/BackToTopButton";
 import DocSidebar from "@theme/DocSidebar";
-import IconArrow from "@theme/IconArrow";
+import IconArrow from "@theme/Icon/Arrow";
 import Layout from "@theme/Layout";
 import MDXComponents from "@theme/MDXComponents";
 import NotFound from "@theme/NotFound";


### PR DESCRIPTION
Docusaurus recently had a breaking change for the path of the icon assets.

Using the latest version of this package with `2.0.0-rc.1` results in:

```
Module not found: Error: Can't resolve '@theme/IconArrow' in '/Users/sean/Documents/devonite/projects/docusaurus-docs-toolchain/node_modules/docusaurus-theme-openapi/lib-next/theme/ApiPage'
```

Docusaurus PR for reference: https://github.com/facebook/docusaurus/pull/7740

This PR updates the path to the new location, resolving the error with rc.1 and later. 
