### PR TITLE
Persist server variables configuration

### DIFF
--- a/packages/docusaurus-theme-openapi/src/theme/ApiDemoPanel/Server/index.tsx
+++ b/packages/docusaurus-theme-openapi/src/theme/ApiDemoPanel/Server/index.tsx
@@ -38,7 +38,7 @@ function Server() {
         Object.keys(value.variables).forEach((variable) => {
           url = url.replace(
             `{${variable}}`,
-            value.variables?.[variable].default ?? ""
+            value.variables?.[variable].storedValue ?? ""
           );
         });
       }
@@ -78,6 +78,7 @@ function Server() {
               <FormItem label={key}>
                 <FormSelect
                   options={value.variables[key].enum}
+                  value={value.variables?.[key].storedValue}
                   onChange={(e) => {
                     dispatch(setServerVariable({ key, value: e.target.value }));
                   }}
@@ -89,6 +90,7 @@ function Server() {
             <FormItem label={key}>
               <FormTextInput
                 placeholder={value.variables?.[key].default}
+                value={value.variables?.[key].storedValue}
                 onChange={(e) => {
                   dispatch(setServerVariable({ key, value: e.target.value }));
                 }}

--- a/packages/docusaurus-theme-openapi/src/theme/ApiDemoPanel/Server/slice.ts
+++ b/packages/docusaurus-theme-openapi/src/theme/ApiDemoPanel/Server/slice.ts
@@ -11,6 +11,7 @@ import {
   ServerObject,
   ServerVariable,
 } from "docusaurus-plugin-openapi/src/openapi/types";
+
 import { ThemeConfig } from "../../../types";
 import { createStorage } from "../storage-utils";
 

--- a/packages/docusaurus-theme-openapi/src/theme/ApiDemoPanel/buildPostmanRequest.ts
+++ b/packages/docusaurus-theme-openapi/src/theme/ApiDemoPanel/buildPostmanRequest.ts
@@ -5,10 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  * ========================================================================== */
 
-import {
-  ParameterObject,
-  ServerObject,
-} from "docusaurus-plugin-openapi/src/openapi/types";
+import { ParameterObject } from "docusaurus-plugin-openapi/src/openapi/types";
 import cloneDeep from "lodash/cloneDeep";
 import sdk from "postman-collection";
 

--- a/packages/docusaurus-theme-openapi/src/theme/ApiDemoPanel/buildPostmanRequest.ts
+++ b/packages/docusaurus-theme-openapi/src/theme/ApiDemoPanel/buildPostmanRequest.ts
@@ -14,6 +14,7 @@ import sdk from "postman-collection";
 
 import { AuthState, Scheme } from "./Authorization/slice";
 import { Body, Content } from "./Body/slice";
+import { ServerObjectWithStorage } from "./Server/slice";
 
 type Param = {
   value?: string | string[];
@@ -191,7 +192,7 @@ function setBody(clonedPostman: sdk.Request, body: Body) {
 
 // TODO: finish these types
 interface Options {
-  server?: ServerObject;
+  server?: ServerObjectWithStorage;
   queryParams: Param[];
   pathParams: Param[];
   cookieParams: Param[];
@@ -226,7 +227,7 @@ function buildPostmanRequest(
     const variables = server.variables;
     if (variables) {
       Object.keys(variables).forEach((variable) => {
-        url = url.replace(`{${variable}}`, variables[variable].default);
+        url = url.replace(`{${variable}}`, variables[variable].storedValue);
       });
     }
     clonedPostman.url.host = [url];

--- a/packages/docusaurus-theme-openapi/src/theme/ApiDemoPanel/index.tsx
+++ b/packages/docusaurus-theme-openapi/src/theme/ApiDemoPanel/index.tsx
@@ -27,6 +27,7 @@ import Response from "./Response";
 import Server from "./Server";
 import { createStoreWithState } from "./store";
 import styles from "./styles.module.css";
+import { createServer } from "./Server/slice";
 
 function ApiDemoPanel({ item }: { item: NonNullable<Metadata["api"]> }) {
   const { siteConfig } = useDocusaurusContext();
@@ -66,13 +67,18 @@ function ApiDemoPanel({ item }: { item: NonNullable<Metadata["api"]> }) {
     options,
   });
 
+  const server = createServer({
+    servers,
+    options,
+  });
+
   const persistanceMiddleware = createPersistanceMiddleware(options);
 
   const store2 = createStoreWithState(
     {
       accept: { value: acceptArray[0], options: acceptArray },
       contentType: { value: contentTypeArray[0], options: contentTypeArray },
-      server: { value: servers[0], options: servers },
+      server: server,
       response: { value: undefined },
       body: { type: "empty" },
       params,

--- a/packages/docusaurus-theme-openapi/src/theme/ApiDemoPanel/index.tsx
+++ b/packages/docusaurus-theme-openapi/src/theme/ApiDemoPanel/index.tsx
@@ -25,9 +25,9 @@ import ParamOptions from "./ParamOptions";
 import { createPersistanceMiddleware } from "./persistanceMiddleware";
 import Response from "./Response";
 import Server from "./Server";
+import { createServer } from "./Server/slice";
 import { createStoreWithState } from "./store";
 import styles from "./styles.module.css";
-import { createServer } from "./Server/slice";
 
 function ApiDemoPanel({ item }: { item: NonNullable<Metadata["api"]> }) {
   const { siteConfig } = useDocusaurusContext();

--- a/packages/docusaurus-theme-openapi/src/theme/ApiDemoPanel/persistanceMiddleware.ts
+++ b/packages/docusaurus-theme-openapi/src/theme/ApiDemoPanel/persistanceMiddleware.ts
@@ -9,6 +9,7 @@ import { Middleware } from "@reduxjs/toolkit";
 
 import { ThemeConfig } from "../../types";
 import { setAuthData, setSelectedAuth } from "./Authorization/slice";
+import { setServer, setServerVariable } from "./Server/slice";
 import { createStorage, hashArray } from "./storage-utils";
 import { AppDispatch, RootState } from "./store";
 
@@ -36,6 +37,25 @@ export function createPersistanceMiddleware(options: ThemeConfig["api"]) {
           storage.setItem(
             hashArray(Object.keys(state.auth.options)),
             state.auth.selected
+          );
+        }
+      }
+
+      if (action.type === setServer.type) {
+        if (state.server.value?.url) {
+          // FIXME What to use as key?
+          storage.setItem(
+            `docusaurus.openapi.server/${state.server.value?.url}`,
+            JSON.stringify(state.server.value)
+          );
+        }
+      }
+
+      if (action.type === setServerVariable.type) {
+        if (state.server.value?.url) {
+          storage.setItem(
+            `docusaurus.openapi.server/${state.server.value?.url}`,
+            JSON.stringify(state.server.value)
           );
         }
       }

--- a/packages/docusaurus-theme-openapi/src/types.ts
+++ b/packages/docusaurus-theme-openapi/src/types.ts
@@ -9,5 +9,6 @@ export interface ThemeConfig {
   api?: {
     proxy?: string;
     authPersistance?: false | "localStorage" | "sessionStorage";
+    serverVariablesPersistance?: false | "localStorage" | "sessionStorage";
   };
 }


### PR DESCRIPTION
This PR allows users to configure whether they want to store server variables within the browser, similar to what already happens with `authPersistance`.

@bourdakos1 I tried to keep the diff as small as possible