### PR TITLE
add example key `serverVariablesPersistance` in demo

### DIFF
--- a/demo/docusaurus.config.js
+++ b/demo/docusaurus.config.js
@@ -118,6 +118,7 @@ const config = {
       },
       api: {
         authPersistance: "localStorage",
+        serverVariablesPersistance: "localStorage",
       },
     }),
 };


### PR DESCRIPTION
I forgot to add this to the previous PR #202. We could add the `serverVariablesPersistance` config key in the demo, for documenting its existence.