### PR TITLE
fix: resolve fallback of url

### DIFF
--- a/packages/docusaurus-template-openapi/template.json
+++ b/packages/docusaurus-template-openapi/template.json
@@ -21,7 +21,8 @@
       "clsx": "^1.1.1",
       "prism-react-renderer": "^1.2.1",
       "react": "^17.0.1",
-      "react-dom": "^17.0.1"
+      "react-dom": "^17.0.1",
+      "url": "^0.11.0"
     },
     "browserslist": {
       "production": [">0.5%", "not dead", "not op_mini all"],


### PR DESCRIPTION
Add `url` dependency to template.
Without this dependency will result in the `Module not found` error.

<details>
<summary>screenshot of running error</summary>

![图片](https://user-images.githubusercontent.com/68207314/182583515-61006ed0-02b7-4d67-a40c-fd12ebce1e89.png)
</details>

<details>
<summary>related package.json</summary>

```
{
  "name": "docusaurus-openapi-example",
  "version": "0.0.0",
  "private": true,
  "dependencies": {
    "@docusaurus/core": "^2.0.0",
    "docusaurus-preset-openapi": "0.6.0",
    "@mdx-js/react": "^1.6.21",
    "clsx": "^1.1.1",
    "prism-react-renderer": "^1.2.1",
    "react": "^17.0.1",
    "react-dom": "^17.0.1"
  },
  "scripts": {
    "docusaurus": "docusaurus",
    "start": "docusaurus start",
    "build": "docusaurus build",
    "swizzle": "docusaurus swizzle",
    "deploy": "docusaurus deploy",
    "clear": "docusaurus clear",
    "serve": "docusaurus serve",
    "write-translations": "docusaurus write-translations",
    "write-heading-ids": "docusaurus write-heading-ids"
  },
  "browserslist": {
    "production": [
      ">0.5%",
      "not dead",
      "not op_mini all"
    ],
    "development": [
      "last 1 chrome version",
      "last 1 firefox version",
      "last 1 safari version"
    ]
  }
}
```
</details>

