### PR TITLE
feat(auth): authorize with api keys in header

### DIFF
--- a/cypress/integration/test.spec.ts
+++ b/cypress/integration/test.spec.ts
@@ -6,12 +6,22 @@
  * ========================================================================== */
 
 describe("test", () => {
-  it("loads Petstore page", () => {
-    cy.visit("/petstore");
-    navTo(
-      [/^pet$/i, /add a new pet to the store/i],
-      /add a new pet to the store/i
-    );
+  describe("Petstore", () => {
+    it("loads Petstore page", () => {
+      cy.visit("/petstore");
+      navTo(
+        [/^pet$/i, /add a new pet to the store/i],
+        /add a new pet to the store/i
+      );
+    });
+
+    it("renders authentication header fields", () => {
+      cy.visit("/petstore/find-pet-by-id");
+      cy.findByRole("button", { name: /authorize/i })
+        .should("exist")
+        .click();
+      cy.get('input[placeholder="api_key"]').should("exist");
+    });
   });
 
   it("loads Cloud Object Storage page", () => {

--- a/packages/docusaurus-plugin-openapi/src/openapi/openapi.ts
+++ b/packages/docusaurus-plugin-openapi/src/openapi/openapi.ts
@@ -124,7 +124,9 @@ function createItems(openapiData: OpenApiObject): ApiMetadata[] {
       const security = operationObject.security ?? openapiData.security;
 
       // Add security schemes so we know how to handle security.
-      const securitySchemes = openapiData.components?.securitySchemes;
+      const securitySchemes =
+        openapiData.components?.securitySchemes ??
+        openapiData.securityDefinitions;
 
       // Make sure schemes are lowercase. See: https://github.com/cloud-annotations/docusaurus-plugin-openapi/issues/79
       if (securitySchemes) {

--- a/packages/docusaurus-plugin-openapi/src/openapi/types.ts
+++ b/packages/docusaurus-plugin-openapi/src/openapi/types.ts
@@ -17,6 +17,10 @@ export interface OpenApiObject {
   servers?: ServerObject[];
   paths: PathsObject;
   components?: ComponentsObject;
+  /**
+   * @deprecated in 3.0.0 - use components.securitySchemes instead
+   */
+  securityDefinitions?: Map<SecuritySchemeObject>;
   security?: SecurityRequirementObject[];
   tags?: TagObject[];
   externalDocs?: ExternalDocumentationObject;

--- a/packages/docusaurus-theme-openapi/src/theme/ApiDemoPanel/Authorization/index.tsx
+++ b/packages/docusaurus-theme-openapi/src/theme/ApiDemoPanel/Authorization/index.tsx
@@ -167,7 +167,7 @@ function Authorization() {
 
           if (a.type === "apiKey") {
             return (
-              <FormItem label={a.key} key={a.key + "-apiKey"}>
+              <FormItem label={a.name} key={a.key + "-apiKey"}>
                 <FormTextInput
                   placeholder={a.name}
                   onChange={(e) => {

--- a/packages/docusaurus-theme-openapi/src/theme/ApiDemoPanel/Authorization/index.tsx
+++ b/packages/docusaurus-theme-openapi/src/theme/ApiDemoPanel/Authorization/index.tsx
@@ -165,6 +165,26 @@ function Authorization() {
             );
           }
 
+          if (a.type === "apiKey") {
+            return (
+              <FormItem label={a.key} key={a.key + "-apiKey"}>
+                <FormTextInput
+                  placeholder={a.name}
+                  onChange={(e) => {
+                    const value = e.target.value.trim();
+                    dispatch(
+                      setAuthData({
+                        scheme: a.key,
+                        key: a.name,
+                        value: value ? value : undefined,
+                      })
+                    );
+                  }}
+                />
+              </FormItem>
+            );
+          }
+
           return null;
         })}
         <LockButton

--- a/packages/docusaurus-theme-openapi/src/theme/ApiDemoPanel/Authorization/slice.ts
+++ b/packages/docusaurus-theme-openapi/src/theme/ApiDemoPanel/Authorization/slice.ts
@@ -132,6 +132,9 @@ export const slice = createSlice({
       action: PayloadAction<{ scheme: string; key: string; value?: string }>
     ) => {
       const { scheme, key, value } = action.payload;
+      if (!state.data[scheme]) {
+        state.data[scheme] = {};
+      }
       state.data[scheme][key] = value;
     },
     setSelectedAuth: (state, action: PayloadAction<string>) => {

--- a/packages/docusaurus-theme-openapi/src/theme/ApiDemoPanel/buildPostmanRequest.ts
+++ b/packages/docusaurus-theme-openapi/src/theme/ApiDemoPanel/buildPostmanRequest.ts
@@ -267,6 +267,18 @@ function buildPostmanRequest(
       });
       continue;
     }
+
+    if (a.type === "apiKey" && a.in === "header") {
+      if (auth.data && auth.data[a.key]) {
+        const value = auth.data[a.key][a.name];
+        if (value) {
+          otherHeaders.push({
+            key: a.name,
+            value,
+          });
+        }
+      }
+    }
   }
 
   setHeaders(


### PR DESCRIPTION
This PR adds support for authorizing with api keys in the http request headers (as seen in the [swagger example](https://user-images.githubusercontent.com/13732623/182992344-8f6eca06-8564-458d-b622-ed7dd1b234e5.png)).

When selecting "Authorize" the list of available header options will display as form inputs:

<img width="458" alt="Screen Shot 2022-08-04 at 11 06 44 PM" src="https://user-images.githubusercontent.com/13732623/182993045-6c87ae98-50e6-4790-9b5e-36d2e8ac885d.png">

After the user specifies values, performing a request will append the values as headers to the request. 

<img width="1438" alt="Screen Shot 2022-08-04 at 10 57 05 PM" src="https://user-images.githubusercontent.com/13732623/182992041-102e8f04-ee0e-4b3b-964c-75518b9a0d1e.png">

This PR also adds a fallback to the OpenAPI spec to support 2.0 (when `securitySchemes` was a top-level object). 

I am unable to share the contents of the OpenAPI spec. Please let me know how I can help validate these changes for approval. 