### PR TITLE
Prepare release v0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 0.6.2 (Aug 11, 2022)
+
+High level enhancements
+
+- Authorize with api keys in header
+
+Other enhancements and bug fixes
+
+- feat(auth): authorize with api keys in header ([#208](https://github.com/cloud-annotations/docusaurus-openapi/pull/208))
+- add example key serverVariablesPersistance in demo ([#204](https://github.com/cloud-annotations/docusaurus-openapi/pull/204))
+
 ## 0.6.1 (Aug 3, 2022)
 
 Other enhancements and bug fixes

--- a/demo/package.json
+++ b/demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "demo",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",
@@ -18,7 +18,7 @@
     "@mdx-js/react": "^1.6.22",
     "@svgr/webpack": "^5.5.0",
     "clsx": "^1.1.1",
-    "docusaurus-preset-openapi": "^0.6.1",
+    "docusaurus-preset-openapi": "^0.6.2",
     "file-loader": "^6.2.0",
     "prism-react-renderer": "^1.2.1",
     "react": "^17.0.2",

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.6.1",
+  "version": "0.6.2",
   "npmClient": "yarn",
   "useWorkspaces": true
 }

--- a/packages/create-docusaurus-openapi/package.json
+++ b/packages/create-docusaurus-openapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-docusaurus-openapi",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Create Docusaurus apps easily.",
   "repository": {
     "type": "git",

--- a/packages/docusaurus-plugin-openapi/package.json
+++ b/packages/docusaurus-plugin-openapi/package.json
@@ -1,7 +1,7 @@
 {
   "name": "docusaurus-plugin-openapi",
   "description": "OpenAPI plugin for Docusaurus.",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/docusaurus-plugin-proxy/package.json
+++ b/packages/docusaurus-plugin-proxy/package.json
@@ -1,7 +1,7 @@
 {
   "name": "docusaurus-plugin-proxy",
   "description": "A dev server proxy for Docusaurus.",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/docusaurus-preset-openapi/package.json
+++ b/packages/docusaurus-preset-openapi/package.json
@@ -1,7 +1,7 @@
 {
   "name": "docusaurus-preset-openapi",
   "description": "OpenAPI preset for Docusaurus.",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "license": "MIT",
   "keywords": [
     "openapi",
@@ -32,9 +32,9 @@
   },
   "dependencies": {
     "@docusaurus/preset-classic": "^2.0.0",
-    "docusaurus-plugin-openapi": "^0.6.1",
-    "docusaurus-plugin-proxy": "^0.6.1",
-    "docusaurus-theme-openapi": "^0.6.1"
+    "docusaurus-plugin-openapi": "^0.6.2",
+    "docusaurus-plugin-proxy": "^0.6.2",
+    "docusaurus-theme-openapi": "^0.6.2"
   },
   "peerDependencies": {
     "react": "^16.8.4 || ^17.0.0",

--- a/packages/docusaurus-template-openapi/package.json
+++ b/packages/docusaurus-template-openapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docusaurus-template-openapi",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "keywords": [
     "react",
     "create-docusaurus",

--- a/packages/docusaurus-theme-openapi/package.json
+++ b/packages/docusaurus-theme-openapi/package.json
@@ -1,7 +1,7 @@
 {
   "name": "docusaurus-theme-openapi",
   "description": "OpenAPI theme for Docusaurus.",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "license": "MIT",
   "publishConfig": {
     "access": "public"
@@ -43,7 +43,7 @@
     "buffer": "^6.0.3",
     "clsx": "^1.1.1",
     "crypto-js": "^4.1.1",
-    "docusaurus-plugin-openapi": "^0.6.1",
+    "docusaurus-plugin-openapi": "^0.6.2",
     "immer": "^9.0.7",
     "lodash": "^4.17.20",
     "monaco-editor": "^0.31.1",


### PR DESCRIPTION
Bumps the version for 0.6.2.

Let me know if I missed something here. I had issues with the changelog fetching the upstream, so I manually prepared the change based on what the script outputs. 