### PR TITLE
Hide required labels on response schemas

### DIFF
--- a/packages/docusaurus-plugin-openapi/src/markdown/createRequestBodyTable.ts
+++ b/packages/docusaurus-plugin-openapi/src/markdown/createRequestBodyTable.ts
@@ -13,5 +13,5 @@ interface Props {
 }
 
 export function createRequestBodyTable({ title, body }: Props) {
-  return createSchemaTable({ title, body });
+  return createSchemaTable({ title, body, type: "request" });
 }

--- a/packages/docusaurus-plugin-openapi/src/markdown/createStatusCodesTable.ts
+++ b/packages/docusaurus-plugin-openapi/src/markdown/createStatusCodesTable.ts
@@ -64,6 +64,9 @@ export function createStatusCodesTable({ responses }: Props) {
                     body: {
                       content: responses[code].content,
                     },
+                    options: {
+                      showRequiredLabel: false,
+                    },
                   }),
                 }),
               ],

--- a/packages/docusaurus-plugin-openapi/src/markdown/createStatusCodesTable.ts
+++ b/packages/docusaurus-plugin-openapi/src/markdown/createStatusCodesTable.ts
@@ -64,9 +64,7 @@ export function createStatusCodesTable({ responses }: Props) {
                     body: {
                       content: responses[code].content,
                     },
-                    options: {
-                      showRequiredLabel: false,
-                    },
+                    type: "response",
                   }),
                 }),
               ],

--- a/packages/docusaurus-theme-openapi/src/theme/ApiPage/styles.module.css
+++ b/packages/docusaurus-theme-openapi/src/theme/ApiPage/styles.module.css
@@ -33,6 +33,7 @@
   --api-sidebar-hidden-width: 30px;
 
   --openapi-required: var(--openapi-code-red);
+  --openapi-optional: var(--openapi-code-dim);
 
   --openapi-card-background-color: #f6f8fa;
   --openapi-card-border-radius: var(--ifm-pre-border-radius);
@@ -62,6 +63,7 @@ html[data-theme="dark"] {
   --openapi-monaco-border-color: #606770;
 
   --openapi-required: var(--openapi-code-red);
+  --openapi-optional: var(--openapi-code-dim);
 
   --openapi-card-background-color: var(--ifm-card-background-color);
 


### PR DESCRIPTION
I thought it was a bit strange to display `REQUIRED` in response schemas. I added an option to disable it. I think it is a good default option, but we can let the user parametrize this.

What do you think?

### Before

<img width="1163" alt="CleanShot 2022-11-22 at 11 16 53@2x" src="https://user-images.githubusercontent.com/16015833/203291567-c1b1950b-1502-4c99-b00a-70f35e6e6014.png">

### After

<img width="1163" alt="CleanShot 2022-11-22 at 11 32 03@2x" src="https://user-images.githubusercontent.com/16015833/203291583-76e37236-711c-4b99-8fa9-36b438624549.png">
