### PR TITLE
Ensure path-level parameters are passed to the theme

### DIFF
--- a/packages/docusaurus-plugin-openapi/src/openapi/openapi.ts
+++ b/packages/docusaurus-plugin-openapi/src/openapi/openapi.ts
@@ -161,6 +161,9 @@ function createItems(openapiData: OpenApiObject): ApiMetadata[] {
           ),
           method,
           path,
+          parameters: (operationObject.parameters ?? []).concat(
+            pathObject.parameters ?? []
+          ),
           servers,
           security,
           securitySchemes,


### PR DESCRIPTION
The OpenAPI specification allows specifying a set of parameters for an entire path, instead of specifying them specifically for each operation within a path. See https://swagger.io/specification/#path-item-object

Previously, the parameters specified at the path level were ignored. This PR fixes that.

@bourdakos1 