### PR TITLE
Convert some relative imports in theme package

### DIFF
--- a/packages/docusaurus-plugin-openapi/src/plugin-openapi.d.ts
+++ b/packages/docusaurus-plugin-openapi/src/plugin-openapi.d.ts
@@ -132,3 +132,31 @@ declare module "@theme/MarkdownItem" {
   const MarkdownItem: (props: Props) => JSX.Element;
   export default MarkdownItem;
 }
+
+declare module "@theme/ApiDemoPanel" {
+  import type { Metadata } from "@theme/ApiItem";
+
+  export interface Props {
+    readonly item: NonNullable<Metadata["api"]>;
+  }
+
+  const ApiDemoPanel: (props: Props) => JSX.Element;
+  export default ApiDemoPanel;
+}
+
+declare module "@theme/ApiDemoPanel/Curl" {
+  import type { Request } from "postman-collection";
+
+  export interface Props {
+    readonly postman: Request;
+    readonly codeSamples: Array<Any>;
+  }
+
+  const Curl: (props: Props) => JSX.Element;
+  export default Curl;
+}
+
+declare module "@theme/ApiDemoPanel/Response" {
+  const Response: () => JSX.Element;
+  export default Response;
+}

--- a/packages/docusaurus-theme-openapi/src/theme/ApiDemoPanel/Curl/index.tsx
+++ b/packages/docusaurus-theme-openapi/src/theme/ApiDemoPanel/Curl/index.tsx
@@ -8,10 +8,10 @@
 import React, { useRef, useState, useEffect } from "react";
 
 import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
+import type { Props } from "@theme/ApiDemoPanel/Curl";
 import clsx from "clsx";
 // @ts-ignore
 import codegen from "postman-code-generators";
-import sdk from "postman-collection";
 import Highlight, { defaultProps } from "prism-react-renderer";
 
 import { useTypedSelector } from "../hooks";
@@ -121,11 +121,6 @@ const languageTheme = {
     },
   ],
 };
-
-interface Props {
-  postman: sdk.Request;
-  codeSamples: any; // TODO: Type this...
-}
 
 function Curl({ postman, codeSamples }: Props) {
   // TODO: match theme for vscode.

--- a/packages/docusaurus-theme-openapi/src/theme/ApiDemoPanel/index.tsx
+++ b/packages/docusaurus-theme-openapi/src/theme/ApiDemoPanel/index.tsx
@@ -8,7 +8,9 @@
 import React from "react";
 
 import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
-import { Metadata } from "@theme/ApiItem";
+import type { Props } from "@theme/ApiDemoPanel";
+import Curl from "@theme/ApiDemoPanel/Curl";
+import Response from "@theme/ApiDemoPanel/Response";
 import { ParameterObject } from "docusaurus-plugin-openapi/src/openapi/types";
 import sdk from "postman-collection";
 import { Provider } from "react-redux";
@@ -18,18 +20,16 @@ import Accept from "./Accept";
 import Authorization from "./Authorization";
 import { createAuth } from "./Authorization/slice";
 import Body from "./Body";
-import Curl from "./Curl";
 import Execute from "./Execute";
 import MethodEndpoint from "./MethodEndpoint";
 import ParamOptions from "./ParamOptions";
 import { createPersistanceMiddleware } from "./persistanceMiddleware";
-import Response from "./Response";
 import Server from "./Server";
 import { createServer } from "./Server/slice";
 import { createStoreWithState } from "./store";
 import styles from "./styles.module.css";
 
-function ApiDemoPanel({ item }: { item: NonNullable<Metadata["api"]> }) {
+function ApiDemoPanel({ item }: Props) {
   const { siteConfig } = useDocusaurusContext();
   const themeConfig = siteConfig.themeConfig as ThemeConfig;
   const options = themeConfig.api;


### PR DESCRIPTION
Refs https://github.com/cloud-annotations/docusaurus-openapi/issues/236

Originally I was planning to submit a PR converting all of the imports, but what I quickly realised is that if you just do this without declaring a types module for each one, the compile process fails with

```
error TS2307: Cannot find module '@theme/ApiDemoPanel/Response' or its corresponding type declarations.
```

or whatever. This does increase the overhead of the job a bit so I have started off (somewhat selfishly 😇) by only converting the two components I am interested in swizzling. I can also confirm that doing this does make the nested components swizzle-able :tada: