### PR TITLE
Fixes and enhancements for array query param handling

### DIFF
--- a/demo/examples/openapi-array-query-params.yaml
+++ b/demo/examples/openapi-array-query-params.yaml
@@ -1,0 +1,43 @@
+openapi: 3.0.3
+info:
+  version: 1.0.0
+  title: ""
+servers:
+  - url: https://example.com
+paths:
+  /Things:
+    get:
+      summary: View Things
+      parameters:
+        - name: "arrayParam"
+          in: "query"
+          required: false
+          description: "You can pass 0, 1 or 2 occurrences of this in the query string"
+          style: "form"
+          explode: true
+          schema:
+            type: "array"
+            maxItems: 2
+            items:
+              type: "string"
+      responses:
+        "200":
+          description: OK
+  /Stuff:
+    get:
+      summary: View Stuff
+      parameters:
+        - name: "arrayParam"
+          in: "query"
+          required: false
+          description: "You can pass 0, 1 or 2 occurrences of this in the query string"
+          style: "pipeDelimited"
+          explode: false
+          schema:
+            type: "array"
+            maxItems: 2
+            items:
+              type: "string"
+      responses:
+        "200":
+          description: OK

--- a/packages/docusaurus-plugin-openapi/src/openapi/types.ts
+++ b/packages/docusaurus-plugin-openapi/src/openapi/types.ts
@@ -179,7 +179,7 @@ export interface ParameterObject {
   allowEmptyValue?: boolean;
   //
   style?: string;
-  explode?: string;
+  explode?: boolean;
   allowReserved?: boolean;
   schema?: SchemaObject;
   example?: any;

--- a/packages/docusaurus-theme-openapi/src/theme/ApiDemoPanel/ParamOptions/index.tsx
+++ b/packages/docusaurus-theme-openapi/src/theme/ApiDemoPanel/ParamOptions/index.tsx
@@ -165,6 +165,12 @@ function ParamArrayFormItem({ param }: ParamProps) {
   const dispatch = useTypedDispatch();
 
   function handleAddItem() {
+    if (
+      param?.schema?.maxItems !== undefined &&
+      items.length >= param.schema.maxItems
+    ) {
+      return;
+    }
     setItems((i) => [
       ...i,
       {
@@ -230,9 +236,12 @@ function ParamArrayFormItem({ param }: ParamProps) {
           </button>
         </div>
       ))}
-      <button className={styles.buttonThin} onClick={handleAddItem}>
-        Add item
-      </button>
+      {(param?.schema?.maxItems == null ||
+        items.length < param.schema.maxItems) && (
+        <button className={styles.buttonThin} onClick={handleAddItem}>
+          Add item
+        </button>
+      )}
     </>
   );
 }

--- a/packages/docusaurus-theme-openapi/src/theme/ApiDemoPanel/ParamOptions/index.tsx
+++ b/packages/docusaurus-theme-openapi/src/theme/ApiDemoPanel/ParamOptions/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  * ========================================================================== */
 
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 
 import { nanoid } from "@reduxjs/toolkit";
 
@@ -19,6 +19,11 @@ import styles from "./styles.module.css";
 
 interface ParamProps {
   param: Param;
+}
+
+interface Item {
+  id: string;
+  value?: string;
 }
 
 function ParamOption({ param }: ParamProps) {
@@ -161,7 +166,7 @@ function ArrayItem({
 }
 
 function ParamArrayFormItem({ param }: ParamProps) {
-  const [items, setItems] = useState<{ id: string; value?: string }[]>([]);
+  const [items, setItems] = useState<Item[]>([]);
   const dispatch = useTypedDispatch();
 
   function handleAddItem() {
@@ -179,7 +184,7 @@ function ParamArrayFormItem({ param }: ParamProps) {
     ]);
   }
 
-  useEffect(() => {
+  function updateItems(items: Array<Item>) {
     const values = items
       .map((item) => item.value)
       .filter((item): item is string => !!item);
@@ -190,12 +195,13 @@ function ParamArrayFormItem({ param }: ParamProps) {
         value: values.length > 0 ? values : undefined,
       })
     );
-  }, [dispatch, items]);
+  }
 
   function handleDeleteItem(itemToDelete: { id: string }) {
     return () => {
       const newItems = items.filter((i) => i.id !== itemToDelete.id);
       setItems(newItems);
+      updateItems(newItems);
     };
   }
 
@@ -208,6 +214,7 @@ function ParamArrayFormItem({ param }: ParamProps) {
         return i;
       });
       setItems(newItems);
+      updateItems(newItems);
     };
   }
 

--- a/packages/docusaurus-theme-openapi/src/theme/ApiDemoPanel/ParamOptions/index.tsx
+++ b/packages/docusaurus-theme-openapi/src/theme/ApiDemoPanel/ParamOptions/index.tsx
@@ -243,9 +243,13 @@ function ParamArrayFormItem({ param }: ParamProps) {
           </button>
         </div>
       ))}
-      {(param?.schema?.maxItems == null ||
+      {((param?.schema?.maxItems == null ||
         items.length < param.schema.maxItems) && (
         <button className={styles.buttonThin} onClick={handleAddItem}>
+          Add item
+        </button>
+      )) || (
+        <button className={styles.buttonThin} disabled>
           Add item
         </button>
       )}

--- a/packages/docusaurus-theme-openapi/src/theme/ApiDemoPanel/ParamOptions/index.tsx
+++ b/packages/docusaurus-theme-openapi/src/theme/ApiDemoPanel/ParamOptions/index.tsx
@@ -184,7 +184,7 @@ function ParamArrayFormItem({ param }: ParamProps) {
         value: values.length > 0 ? values : undefined,
       })
     );
-  }, [dispatch, items, param]);
+  }, [dispatch, items]);
 
   function handleDeleteItem(itemToDelete: { id: string }) {
     return () => {

--- a/packages/docusaurus-theme-openapi/src/theme/ApiDemoPanel/ParamOptions/index.tsx
+++ b/packages/docusaurus-theme-openapi/src/theme/ApiDemoPanel/ParamOptions/index.tsx
@@ -247,7 +247,7 @@ function ParamArrayFormItem({ param }: ParamProps) {
         className={styles.buttonThin}
         onClick={handleAddItem}
         disabled={
-          param?.schema?.maxItems == null ||
+          param?.schema?.maxItems != null &&
           items.length >= param.schema.maxItems
         }
       >

--- a/packages/docusaurus-theme-openapi/src/theme/ApiDemoPanel/ParamOptions/index.tsx
+++ b/packages/docusaurus-theme-openapi/src/theme/ApiDemoPanel/ParamOptions/index.tsx
@@ -243,16 +243,16 @@ function ParamArrayFormItem({ param }: ParamProps) {
           </button>
         </div>
       ))}
-      {((param?.schema?.maxItems == null ||
-        items.length < param.schema.maxItems) && (
-        <button className={styles.buttonThin} onClick={handleAddItem}>
-          Add item
-        </button>
-      )) || (
-        <button className={styles.buttonThin} disabled>
-          Add item
-        </button>
-      )}
+      <button
+        className={styles.buttonThin}
+        onClick={handleAddItem}
+        disabled={
+          param?.schema?.maxItems == null ||
+          items.length >= param.schema.maxItems
+        }
+      >
+        Add item
+      </button>
     </>
   );
 }

--- a/packages/docusaurus-theme-openapi/src/theme/ApiDemoPanel/buildPostmanRequest.test.ts
+++ b/packages/docusaurus-theme-openapi/src/theme/ApiDemoPanel/buildPostmanRequest.test.ts
@@ -1,0 +1,79 @@
+/* ============================================================================
+ * Copyright (c) Cloud Annotations
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ * ========================================================================== */
+
+import sdk from "postman-collection";
+
+import { openApiQueryParams2PostmanQueryParams } from "./buildPostmanRequest";
+
+describe("openApiQueryParams2PostmanQueryParams", () => {
+  it("should transform empty array to empty array", () => {
+    const expected: sdk.QueryParam[] = [];
+    const actual = openApiQueryParams2PostmanQueryParams([]);
+    expect(actual).toStrictEqual(expected);
+  });
+
+  it("default to comma delimited", () => {
+    const expected: sdk.QueryParam[] = [
+      new sdk.QueryParam({ key: "arrayParam", value: "abc,def" }),
+    ];
+    const actual = openApiQueryParams2PostmanQueryParams([
+      {
+        name: "arrayParam",
+        in: "query",
+        value: ["abc", "def"],
+      },
+    ]);
+    expect(actual).toStrictEqual(expected);
+  });
+
+  it("should expand params if explode=true", () => {
+    const expected: sdk.QueryParam[] = [
+      new sdk.QueryParam({ key: "arrayParam", value: "abc" }),
+      new sdk.QueryParam({ key: "arrayParam", value: "def" }),
+    ];
+    const actual = openApiQueryParams2PostmanQueryParams([
+      {
+        name: "arrayParam",
+        in: "query",
+        style: "form",
+        explode: true,
+        value: ["abc", "def"],
+      },
+    ]);
+    expect(actual).toStrictEqual(expected);
+  });
+
+  it("should respect style=pipeDelimited", () => {
+    const expected: sdk.QueryParam[] = [
+      new sdk.QueryParam({ key: "arrayParam", value: "abc|def" }),
+    ];
+    const actual = openApiQueryParams2PostmanQueryParams([
+      {
+        name: "arrayParam",
+        in: "query",
+        style: "pipeDelimited",
+        value: ["abc", "def"],
+      },
+    ]);
+    expect(actual).toStrictEqual(expected);
+  });
+
+  it("should respect style=spaceDelimited", () => {
+    const expected: sdk.QueryParam[] = [
+      new sdk.QueryParam({ key: "arrayParam", value: "abc%20def" }),
+    ];
+    const actual = openApiQueryParams2PostmanQueryParams([
+      {
+        name: "arrayParam",
+        in: "query",
+        style: "spaceDelimited",
+        value: ["abc", "def"],
+      },
+    ]);
+    expect(actual).toStrictEqual(expected);
+  });
+});


### PR DESCRIPTION
This PR is a bit of a mixed bag of related things.

1. There is an infinite render loop on pages that use query params, causing a `Maximum Update Depth Exceeded` error.

2. Respect the `maxItems` property for array query params.

3. OpenAPI supports number of different [styles for array query params](https://swagger.io/docs/specification/serialization/#query) via the `style` and `explode` properties. This PR adds compatibility for those.