### PR TITLE
Prepare release v0.6.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+## 0.6.4 (Mar 15, 2023)
+
+High level enhancements
+
+- Fixes and enhancements for array query param handling ([#241](https://github.com/cloud-annotations/docusaurus-openapi/pull/241))
+  - Respect the `maxItems` property for array query params
+  - Add compatibility for `style` and `explode` properties when rendering array query params
+  - Fix infinite render loop on pages using array query params
+
+Other enhancements and bug fixes
+
+- Convert some relative imports in theme package ([#237](https://github.com/cloud-annotations/docusaurus-openapi/pull/237))
+- Ensure path-level parameters are passed to the theme ([#235](https://github.com/cloud-annotations/docusaurus-openapi/pull/235))
+- Hide required labels on response schemas ([#230](https://github.com/cloud-annotations/docusaurus-openapi/pull/230))
+- Fix invalid ignore pattern for underscore files ([#233](https://github.com/cloud-annotations/docusaurus-openapi/pull/233))
+- Add existing site install instructions ([#229](https://github.com/cloud-annotations/docusaurus-openapi/pull/229))
+- Docs: update template version ([#225](https://github.com/cloud-annotations/docusaurus-openapi/pull/225))
+
 ## 0.6.3 (Nov 7, 2022)
 
 High level enhancements

--- a/demo/package.json
+++ b/demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "demo",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",
@@ -18,7 +18,7 @@
     "@mdx-js/react": "^1.6.22",
     "@svgr/webpack": "^5.5.0",
     "clsx": "^1.1.1",
-    "docusaurus-preset-openapi": "^0.6.3",
+    "docusaurus-preset-openapi": "^0.6.4",
     "file-loader": "^6.2.0",
     "prism-react-renderer": "^1.2.1",
     "react": "^17.0.2",

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.6.3",
+  "version": "0.6.4",
   "npmClient": "yarn",
   "useWorkspaces": true
 }

--- a/packages/create-docusaurus-openapi/package.json
+++ b/packages/create-docusaurus-openapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-docusaurus-openapi",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "Create Docusaurus apps easily.",
   "repository": {
     "type": "git",

--- a/packages/docusaurus-plugin-openapi/package.json
+++ b/packages/docusaurus-plugin-openapi/package.json
@@ -1,7 +1,7 @@
 {
   "name": "docusaurus-plugin-openapi",
   "description": "OpenAPI plugin for Docusaurus.",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/docusaurus-preset-openapi/package.json
+++ b/packages/docusaurus-preset-openapi/package.json
@@ -1,7 +1,7 @@
 {
   "name": "docusaurus-preset-openapi",
   "description": "OpenAPI preset for Docusaurus.",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "license": "MIT",
   "keywords": [
     "openapi",
@@ -32,9 +32,9 @@
   },
   "dependencies": {
     "@docusaurus/preset-classic": "^2.0.0",
-    "docusaurus-plugin-openapi": "^0.6.3",
+    "docusaurus-plugin-openapi": "^0.6.4",
     "docusaurus-plugin-proxy": "^0.6.3",
-    "docusaurus-theme-openapi": "^0.6.3"
+    "docusaurus-theme-openapi": "^0.6.4"
   },
   "peerDependencies": {
     "react": "^16.8.4 || ^17.0.0",

--- a/packages/docusaurus-template-openapi/package.json
+++ b/packages/docusaurus-template-openapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docusaurus-template-openapi",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "keywords": [
     "react",
     "create-docusaurus",

--- a/packages/docusaurus-template-openapi/template.json
+++ b/packages/docusaurus-template-openapi/template.json
@@ -1,7 +1,7 @@
 {
   "package": {
     "name": "demo",
-    "version": "0.6.3",
+    "version": "0.6.4",
     "private": true,
     "scripts": {
       "docusaurus": "docusaurus",

--- a/packages/docusaurus-theme-openapi/package.json
+++ b/packages/docusaurus-theme-openapi/package.json
@@ -1,7 +1,7 @@
 {
   "name": "docusaurus-theme-openapi",
   "description": "OpenAPI theme for Docusaurus.",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "license": "MIT",
   "publishConfig": {
     "access": "public"
@@ -43,7 +43,7 @@
     "buffer": "^6.0.3",
     "clsx": "^1.1.1",
     "crypto-js": "^4.1.1",
-    "docusaurus-plugin-openapi": "^0.6.3",
+    "docusaurus-plugin-openapi": "^0.6.4",
     "immer": "^9.0.7",
     "lodash": "^4.17.20",
     "monaco-editor": "^0.31.1",


### PR DESCRIPTION
Looks like there are a few bits now backed up since 0.6.3. Hopefully I've done this right.

side note: I like the way you've set this project up so that contributors can propose a release by submitting a PR :) Cool way to both empower contributors and reduce overhead for maintainers.