### PR TITLE
wrap code examples tabs in narrow browser windows

### DIFF
--- a/packages/docusaurus-theme-openapi/src/theme/ApiDemoPanel/Curl/styles.module.css
+++ b/packages/docusaurus-theme-openapi/src/theme/ApiDemoPanel/Curl/styles.module.css
@@ -10,7 +10,8 @@
   border-radius: var(--openapi-card-border-radius)
     var(--openapi-card-border-radius) 2px 2px;
   display: flex;
-  justify-content: flex-end;
+  justify-content: center;
+  flex-wrap: wrap;
 }
 
 .buttonGroup button {
@@ -59,7 +60,6 @@
   /* border-radius: 0.25rem; */
 
   display: block;
-  width: 100%;
 
   /* margin: 2px; */
   margin: var(--margin);


### PR DESCRIPTION
This is a proposed fix for issue https://github.com/cloud-annotations/docusaurus-openapi/issues/249

before

![Screenshot at 2023-06-19 14-23-03](https://github.com/cloud-annotations/docusaurus-openapi/assets/6025893/20705f99-c739-4219-a242-001dcb0a4d45)

after

![Screenshot at 2023-06-19 14-28-15](https://github.com/cloud-annotations/docusaurus-openapi/assets/6025893/4a61bf79-c297-480f-9666-697a3beddd4e)

Potentially there are other ways you could solve this though.