### PR TITLE
Prepare release v0.6.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.6.5 (Jun 19, 2023)
+
+Bug fixes
+
+- Wrap code examples tabs in narrow browser windows ([#250](https://github.com/cloud-annotations/docusaurus-openapi/pull/250))
+
 ## 0.6.4 (Mar 15, 2023)
 
 High level enhancements

--- a/demo/package.json
+++ b/demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "demo",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",
@@ -18,7 +18,7 @@
     "@mdx-js/react": "^1.6.22",
     "@svgr/webpack": "^5.5.0",
     "clsx": "^1.1.1",
-    "docusaurus-preset-openapi": "^0.6.4",
+    "docusaurus-preset-openapi": "^0.6.5",
     "file-loader": "^6.2.0",
     "prism-react-renderer": "^1.2.1",
     "react": "^17.0.2",

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.6.4",
+  "version": "0.6.5",
   "npmClient": "yarn",
   "useWorkspaces": true
 }

--- a/packages/docusaurus-preset-openapi/package.json
+++ b/packages/docusaurus-preset-openapi/package.json
@@ -1,7 +1,7 @@
 {
   "name": "docusaurus-preset-openapi",
   "description": "OpenAPI preset for Docusaurus.",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "license": "MIT",
   "keywords": [
     "openapi",
@@ -34,7 +34,7 @@
     "@docusaurus/preset-classic": "^2.0.0",
     "docusaurus-plugin-openapi": "^0.6.4",
     "docusaurus-plugin-proxy": "^0.6.3",
-    "docusaurus-theme-openapi": "^0.6.4"
+    "docusaurus-theme-openapi": "^0.6.5"
   },
   "peerDependencies": {
     "react": "^16.8.4 || ^17.0.0",

--- a/packages/docusaurus-template-openapi/template.json
+++ b/packages/docusaurus-template-openapi/template.json
@@ -16,7 +16,7 @@
     },
     "dependencies": {
       "@docusaurus/core": "^2.0.0",
-      "docusaurus-preset-openapi": "0.6.3",
+      "docusaurus-preset-openapi": "0.6.5",
       "@mdx-js/react": "^1.6.21",
       "clsx": "^1.1.1",
       "prism-react-renderer": "^1.2.1",

--- a/packages/docusaurus-theme-openapi/package.json
+++ b/packages/docusaurus-theme-openapi/package.json
@@ -1,7 +1,7 @@
 {
   "name": "docusaurus-theme-openapi",
   "description": "OpenAPI theme for Docusaurus.",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "license": "MIT",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Small theme patch release, with just https://github.com/cloud-annotations/docusaurus-openapi/pull/250