### PR TITLE
add border to form inputs when using light them

### DIFF
--- a/packages/docusaurus-theme-openapi/src/theme/ApiDemoPanel/FormMultiSelect/styles.module.css
+++ b/packages/docusaurus-theme-openapi/src/theme/ApiDemoPanel/FormMultiSelect/styles.module.css
@@ -13,6 +13,12 @@
   border: 2px solid transparent;
 }
 
+html[data-theme="light"] .selectInput {
+  border-color: var(--ifm-color-primary-lightest);
+  border-style: solid;
+  border-width: 1px;
+}
+
 .selectInput {
   composes: inputBase;
   -moz-appearance: none;

--- a/packages/docusaurus-theme-openapi/src/theme/ApiDemoPanel/FormSelect/styles.module.css
+++ b/packages/docusaurus-theme-openapi/src/theme/ApiDemoPanel/FormSelect/styles.module.css
@@ -34,6 +34,12 @@ html[data-theme="dark"] .selectInput {
   background-size: auto auto;
 }
 
+html[data-theme="light"] .selectInput {
+  border-color: var(--ifm-color-primary-lightest);
+  border-style: solid;
+  border-width: 1px;
+}
+
 .selectInput {
   composes: inputBase;
   -moz-appearance: none;

--- a/packages/docusaurus-theme-openapi/src/theme/ApiDemoPanel/FormTextInput/styles.module.css
+++ b/packages/docusaurus-theme-openapi/src/theme/ApiDemoPanel/FormTextInput/styles.module.css
@@ -12,6 +12,12 @@
   border-radius: 4px;
 }
 
+html[data-theme="light"] .input {
+  border-color: var(--ifm-color-primary-lightest);
+  border-style: solid;
+  border-width: 1px;
+}
+
 .input {
   composes: inputBase;
 }


### PR DESCRIPTION
Using the default light theme, the form inputs aren't very obvious, especially the text inputs. We had feedback from a couple of users of our site indicating they didn't know there were form fields there at all.

This is less of an issue with the dark theme as the form inputs have a clearly different background colour.

This PR adds a thin border to form inputs when using the light theme.

**Before:**

![Screenshot at 2023-07-10 11-00-46](https://github.com/cloud-annotations/docusaurus-openapi/assets/6025893/8c10f73e-2747-4b5e-a227-96023e259c66)

**After:**

![Screenshot at 2023-07-10 11-17-12](https://github.com/cloud-annotations/docusaurus-openapi/assets/6025893/8ce3c383-cbf1-428a-b02e-558fa2d5f08e)
