### PR TITLE
render examples in a `<code>` block

### DIFF
--- a/packages/docusaurus-plugin-openapi/src/markdown/createParamsTable.ts
+++ b/packages/docusaurus-plugin-openapi/src/markdown/createParamsTable.ts
@@ -85,7 +85,10 @@ export function createParamsTable({ parameters, type }: Props) {
                 guard(param.example, (example) =>
                   create("div", {
                     style: { marginTop: "var(--ifm-table-cell-padding)" },
-                    children: escape(`Example: ${example}`),
+                    children: [
+                      "Example: ",
+                      create("code", { children: escape(example) }),
+                    ],
                   })
                 ),
                 guard(param.examples, (examples) =>
@@ -93,7 +96,10 @@ export function createParamsTable({ parameters, type }: Props) {
                     style: { marginTop: "var(--ifm-table-cell-padding)" },
                     children: Object.entries(examples).map(([k, v]) =>
                       create("div", {
-                        children: escape(`Example (${k}): ${v.value}`),
+                        children: [
+                          `Example (${k}): `,
+                          create("code", { children: escape(v.value) }),
+                        ],
                       })
                     ),
                   })


### PR DESCRIPTION
The main thing here is to format the example value distinct from the other documentation text.

I think given these are values that would be passed in as a path or query param, using a `<code>` block is a reasonable, but open to other suggestions on it.