### PR TITLE
 Prevent crash in createExample when a multi variant type is being parsed. All variants are concatinated with '|'. Also added a "null" type wich is not the """null""" type, made sure to extra check against this.

### DIFF
--- a/packages/docusaurus-plugin-openapi/src/markdown/schema.ts
+++ b/packages/docusaurus-plugin-openapi/src/markdown/schema.ts
@@ -5,7 +5,20 @@
  * LICENSE file in the root directory of this source tree.
  * ========================================================================== */
 
-import { SchemaObject } from "../openapi/types";
+import { SchemaObject, PrimitiveSchemaObjectTypes } from "../openapi/types";
+
+function typeToString(
+  type: PrimitiveSchemaObjectTypes | PrimitiveSchemaObjectTypes[] | undefined
+): string {
+  if (type === undefined) {
+    return "schema.type is not defined";
+  }
+  if (type instanceof Array) {
+    return type.reduce((acc, cur) => (acc ? `${acc} | ${cur}` : cur), "");
+  }
+
+  return type;
+}
 
 function prettyName(schema: SchemaObject, circular?: boolean) {
   if (schema.$ref) {
@@ -26,7 +39,7 @@ function prettyName(schema: SchemaObject, circular?: boolean) {
     return schema.xml?.name ?? schema.type;
   }
 
-  return schema.title ?? schema.type;
+  return schema.title ?? typeToString(schema.type);
 }
 
 export function getSchemaName(

--- a/packages/docusaurus-plugin-openapi/src/openapi/createExample.ts
+++ b/packages/docusaurus-plugin-openapi/src/openapi/createExample.ts
@@ -14,6 +14,7 @@ interface OASTypeToTypeMap {
   boolean: boolean;
   object: any;
   array: any[];
+  null: string;
 }
 
 type Primitives = {
@@ -118,17 +119,17 @@ export const sampleFromSchema = (schema: SchemaObject = {}): any => {
   return primitive(schema);
 };
 
-function primitive(schema: SchemaObject = {}) {
+function primitive(schema: SchemaObject = {}): string {
   let { type, format } = schema;
 
   if (type instanceof Array) {
     return type
-      .map(type => primitive({ type, format }))
-      .reduce((acc, cur) => acc ? `${acc} | ${cur}` : `${cur}`, null)
+      .map((type) => primitive({ type, format }))
+      .reduce((acc, cur) => (acc ? `${acc} | ${cur}` : `${cur}`), "");
   }
 
-  if (type === undefined || type === null ) {
-    return;
+  if (type === undefined || type === null) {
+    return "";
   }
 
   let fn = primitives[type]?.default;

--- a/packages/docusaurus-plugin-openapi/src/openapi/createExample.ts
+++ b/packages/docusaurus-plugin-openapi/src/openapi/createExample.ts
@@ -43,6 +43,9 @@ const primitives: Primitives = {
     default: (schema) =>
       typeof schema.default === "boolean" ? schema.default : true,
   },
+  null: {
+    default: () => "null",
+  },
   object: {},
   array: {},
 };
@@ -118,11 +121,21 @@ export const sampleFromSchema = (schema: SchemaObject = {}): any => {
 function primitive(schema: SchemaObject = {}) {
   let { type, format } = schema;
 
-  if (type === undefined) {
+  if (type instanceof Array) {
+    return type
+      .map(type => primitive({ type, format }))
+      .reduce((acc, cur) => acc ? `${acc} | ${cur}` : `${cur}`, null)
+  }
+
+  if (type === undefined || type === null ) {
     return;
   }
 
-  let fn = primitives[type].default;
+  let fn = primitives[type]?.default;
+
+  if (fn === undefined) {
+    return "Unknown Type: " + type;
+  }
 
   if (format !== undefined) {
     fn = primitives[type][format] || fn;

--- a/packages/docusaurus-plugin-openapi/src/openapi/types.ts
+++ b/packages/docusaurus-plugin-openapi/src/openapi/types.ts
@@ -308,6 +308,14 @@ export interface ReferenceObject {
 }
 
 export type JSONSchema = JSONSchema4 | JSONSchema6 | JSONSchema7;
+export type PrimitiveSchemaObjectTypes =
+  | "string"
+  | "number"
+  | "integer"
+  | "boolean"
+  | "object"
+  | "array"
+  | "null";
 export type SchemaObject = Omit<
   JSONSchema,
   | "type"
@@ -320,7 +328,7 @@ export type SchemaObject = Omit<
   | "additionalProperties"
 > & {
   // OpenAPI specific overrides
-  type?: "string" | "number" | "integer" | "boolean" | "object" | "array";
+  type?: PrimitiveSchemaObjectTypes | PrimitiveSchemaObjectTypes[];
   allOf?: SchemaObject[];
   oneOf?: SchemaObject[];
   anyOf?: SchemaObject[];


### PR DESCRIPTION
While running this project on our API generated OAPI spec i found it to be crashing when running into variant types. For instance incase there is an optional field:

```js
"properties": {
  "is_active": {
    "type": [
      "boolean",
      "null"
    ]
  }
 ```
 
 This merge is forwarding my local fix
