### PR TITLE
Avoid scroll-bar in CURL component

### DIFF
--- a/packages/docusaurus-theme-openapi/src/theme/ApiDemoPanel/Curl/index.tsx
+++ b/packages/docusaurus-theme-openapi/src/theme/ApiDemoPanel/Curl/index.tsx
@@ -251,6 +251,7 @@ function Curl({ postman, codeSamples }: Props) {
                 paddingRight: "60px",
                 borderRadius:
                   "2px 2px var(--openapi-card-border-radius) var(--openapi-card-border-radius)",
+                textWrap: "pretty",
               }}
             >
               <code ref={ref}>


### PR DESCRIPTION
Often the content is wider than the side panel. This change avoid the horizontal scroll-bar and shows the complete content.

Example:

https://shields.io/badges/dynamic-json-badge

Before:

![image](https://github.com/cloud-annotations/docusaurus-openapi/assets/59966492/0c456184-72c5-42dd-9d3a-ae761deb5a7d)

![image](https://github.com/cloud-annotations/docusaurus-openapi/assets/59966492/4adef45b-def5-42ff-a191-6688a0f8f845)

After:

![image](https://github.com/cloud-annotations/docusaurus-openapi/assets/59966492/056d4d0f-a179-4d0c-a061-d069cfd09b11)

![image](https://github.com/cloud-annotations/docusaurus-openapi/assets/59966492/8a335712-9fb9-43f2-9ab6-bafec06fbe85)

