### PR TITLE
Prepare release v0.7.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 0.7.6 (Jan 3, 2025)
+
+High-level enhancements
+
+- Fixes for compatibility with Docusaurus 3.6 ([#294](https://github.com/cloud-annotations/docusaurus-openapi/pull/294))
+
+Other enhancements and bug fixes
+
+- Upgrade openapi-to-postmanv2 ([#290](https://github.com/cloud-annotations/docusaurus-openapi/pull/290))
+- Update README.md to remove references of v2 ([#295](https://github.com/cloud-annotations/docusaurus-openapi/pull/295))
+
 ## 0.7.5 (Apr 29, 2024)
 
 Enhancements and bug fixes

--- a/demo/package.json
+++ b/demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "demo",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",
@@ -18,7 +18,7 @@
     "@docusaurus/faster": "^3.6.0",
     "@svgr/webpack": "^5.5.0",
     "clsx": "^1.2.1",
-    "docusaurus-preset-openapi": "^0.7.5",
+    "docusaurus-preset-openapi": "^0.7.6",
     "file-loader": "^6.2.0",
     "prism-react-renderer": "^2.1.0",
     "react": "^18.0.0",

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.7.5",
+  "version": "0.7.6",
   "npmClient": "yarn",
   "useWorkspaces": true
 }

--- a/packages/create-docusaurus-openapi/package.json
+++ b/packages/create-docusaurus-openapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-docusaurus-openapi",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "description": "Create Docusaurus apps easily.",
   "repository": {
     "type": "git",

--- a/packages/docusaurus-plugin-openapi/package.json
+++ b/packages/docusaurus-plugin-openapi/package.json
@@ -1,7 +1,7 @@
 {
   "name": "docusaurus-plugin-openapi",
   "description": "OpenAPI plugin for Docusaurus.",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/docusaurus-plugin-proxy/package.json
+++ b/packages/docusaurus-plugin-proxy/package.json
@@ -1,7 +1,7 @@
 {
   "name": "docusaurus-plugin-proxy",
   "description": "A dev server proxy for Docusaurus.",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/docusaurus-preset-openapi/package.json
+++ b/packages/docusaurus-preset-openapi/package.json
@@ -1,7 +1,7 @@
 {
   "name": "docusaurus-preset-openapi",
   "description": "OpenAPI preset for Docusaurus.",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "license": "MIT",
   "keywords": [
     "openapi",
@@ -32,9 +32,9 @@
   },
   "dependencies": {
     "@docusaurus/preset-classic": "^3.6.0",
-    "docusaurus-plugin-openapi": "^0.7.5",
-    "docusaurus-plugin-proxy": "^0.7.5",
-    "docusaurus-theme-openapi": "^0.7.5"
+    "docusaurus-plugin-openapi": "^0.7.6",
+    "docusaurus-plugin-proxy": "^0.7.6",
+    "docusaurus-theme-openapi": "^0.7.6"
   },
   "peerDependencies": {
     "react": "^18.0.0",

--- a/packages/docusaurus-template-openapi/package.json
+++ b/packages/docusaurus-template-openapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docusaurus-template-openapi",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "keywords": [
     "react",
     "create-docusaurus",

--- a/packages/docusaurus-template-openapi/template.json
+++ b/packages/docusaurus-template-openapi/template.json
@@ -1,7 +1,7 @@
 {
   "package": {
     "name": "demo",
-    "version": "0.7.5",
+    "version": "0.7.6",
     "private": true,
     "scripts": {
       "docusaurus": "docusaurus",
@@ -16,7 +16,7 @@
     },
     "dependencies": {
       "@docusaurus/core": "^3.6.0",
-      "docusaurus-preset-openapi": "0.7.5",
+      "docusaurus-preset-openapi": "0.7.6",
       "@mdx-js/react": "^3.0.0",
       "clsx": "^1.2.1",
       "prism-react-renderer": "^2.1.0",

--- a/packages/docusaurus-theme-openapi/package.json
+++ b/packages/docusaurus-theme-openapi/package.json
@@ -1,7 +1,7 @@
 {
   "name": "docusaurus-theme-openapi",
   "description": "OpenAPI theme for Docusaurus.",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "license": "MIT",
   "publishConfig": {
     "access": "public"
@@ -42,7 +42,7 @@
     "buffer": "^6.0.3",
     "clsx": "^1.2.1",
     "crypto-js": "^4.1.1",
-    "docusaurus-plugin-openapi": "^0.7.5",
+    "docusaurus-plugin-openapi": "^0.7.6",
     "immer": "^9.0.7",
     "lodash": "^4.17.20",
     "marked": "^11.0.0",


### PR DESCRIPTION
Looks like last time the minimum docusaurus version was bumped (to Docusaurus 3.2 in release 0.7.4) this was done in a patch release. I've done the same here.